### PR TITLE
Adding signaling info to readme and removing peerService

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ Headless electron app platform for the cloud 🤕☁✨
 We needed a way to run chrome-based browser experiences inside a container, and to stream that container to [remote clients](https://github.com/bengreenier/browserd/issues/2) using webrtc.
 Browserd (named to indicate it's a browser [daemon](https://en.wikipedia.org/wiki/Daemon_(computing))) uses electron to do so.
 
+## Signaling server
+
+Our service is compatible with any standard WebRTC signaling implementation. If you need a simple one that communicates over HTTP/1.1, [webrtc-signal-http](https://github.com/bengreenier/webrtc-signal-http) is a good option.
+
 ## Configuration
 
 Our service can be configured using a [dotenv](https://www.npmjs.com/package/dotenv) file - `.env` containing one environment variable
 key and value per line. For example `KEY=value`. Below are the possible options:
 
 + `SERVICE_URL` (string) - the web service address (to render)
-+ `PEER_SERVICE` (string) - the window and stream source name
 + `TURN_URL` (string) - a turn address
 + `TURN_USERNAME` (string) - a turn username
 + `TURN_PASSWORD` (string) - a turn password credential

--- a/src/__tests__/signal.spec.ts
+++ b/src/__tests__/signal.spec.ts
@@ -47,10 +47,9 @@ describe("Signal", () => {
   describe("signIn", () => {
     it("should sign in (no other peers)", async () => {
       const expectedPeerName = "peerName";
-      const expectedIsProvider = true;
       const expectedPeerId = "123";
       const expectedUrl = `${defaultCtorArgs.url}/sign_in?` +
-      `peer_name=${expectedPeerName}&is_stream_provider=${expectedIsProvider}`;
+      `peer_name=${expectedPeerName}`;
       const expectedEmptyData = "";
 
       fetchMock.mockResponseOnce(expectedEmptyData, {
@@ -59,7 +58,7 @@ describe("Signal", () => {
         },
       });
 
-      await testInstance.signIn(expectedPeerName, expectedIsProvider);
+      await testInstance.signIn(expectedPeerName);
       expect(testInstance.id).toBe(expectedPeerId);
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith(expectedUrl);
@@ -68,7 +67,6 @@ describe("Signal", () => {
 
     it("should sign in (other peers)", async () => {
       const expectedPeerName = "peerName";
-      const expectedIsProvider = true;
       const expectedPeerId = "123";
       const expectedPeerData = "remotePeer,321,1";
 
@@ -78,7 +76,7 @@ describe("Signal", () => {
         },
       });
 
-      await testInstance.signIn(expectedPeerName, expectedIsProvider);
+      await testInstance.signIn(expectedPeerName);
       expect(parsePeers).toHaveBeenCalledTimes(1);
       expect(parsePeers).toHaveBeenCalledWith(expectedPeerData);
     });
@@ -86,7 +84,7 @@ describe("Signal", () => {
     it("should gracefully fail to sign in", async () => {
       fetchMock.mockRejectOnce(new Error("Mock Failure"));
 
-      await expect(testInstance.signIn("peerName", true)).rejects.toBeInstanceOf(Error);
+      await expect(testInstance.signIn("peerName")).rejects.toBeInstanceOf(Error);
     });
 
     it("should fail if no peer id is returned", async () => {
@@ -94,7 +92,7 @@ describe("Signal", () => {
         headers: {},
       });
 
-      await expect(testInstance.signIn("peerName", true)).rejects.toBeInstanceOf(Error);
+      await expect(testInstance.signIn("peerName")).rejects.toBeInstanceOf(Error);
     });
   });
 
@@ -182,7 +180,7 @@ describe("Signal", () => {
       });
       testInstance.on("peer-message", onPeerMessage);
 
-      await testInstance.signIn("name", true);
+      await testInstance.signIn("name");
       expect(global.setInterval).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(1000);
 
@@ -216,7 +214,7 @@ describe("Signal", () => {
       });
       testInstance.on("peer-update", onPeerUpdate);
 
-      await testInstance.signIn("name", true);
+      await testInstance.signIn("name");
       expect(global.setInterval).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(1000);
 
@@ -244,7 +242,7 @@ describe("Signal", () => {
       });
       testInstance.on("error", onError);
 
-      await testInstance.signIn("name", true);
+      await testInstance.signIn("name");
       expect(global.setInterval).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(1000);
 

--- a/src/__tests__/signal.spec.ts
+++ b/src/__tests__/signal.spec.ts
@@ -47,11 +47,10 @@ describe("Signal", () => {
   describe("signIn", () => {
     it("should sign in (no other peers)", async () => {
       const expectedPeerName = "peerName";
-      const expectedPeerService = "peerService";
       const expectedIsProvider = true;
       const expectedPeerId = "123";
       const expectedUrl = `${defaultCtorArgs.url}/sign_in?` +
-      `peer_name=${expectedPeerName}&peer_service=${expectedPeerService}&is_stream_provider=${expectedIsProvider}`;
+      `peer_name=${expectedPeerName}&is_stream_provider=${expectedIsProvider}`;
       const expectedEmptyData = "";
 
       fetchMock.mockResponseOnce(expectedEmptyData, {
@@ -60,7 +59,7 @@ describe("Signal", () => {
         },
       });
 
-      await testInstance.signIn(expectedPeerName, expectedPeerService, expectedIsProvider);
+      await testInstance.signIn(expectedPeerName, expectedIsProvider);
       expect(testInstance.id).toBe(expectedPeerId);
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith(expectedUrl);
@@ -69,7 +68,6 @@ describe("Signal", () => {
 
     it("should sign in (other peers)", async () => {
       const expectedPeerName = "peerName";
-      const expectedPeerService = "peerService";
       const expectedIsProvider = true;
       const expectedPeerId = "123";
       const expectedPeerData = "remotePeer,321,1";
@@ -80,7 +78,7 @@ describe("Signal", () => {
         },
       });
 
-      await testInstance.signIn(expectedPeerName, expectedPeerService, expectedIsProvider);
+      await testInstance.signIn(expectedPeerName, expectedIsProvider);
       expect(parsePeers).toHaveBeenCalledTimes(1);
       expect(parsePeers).toHaveBeenCalledWith(expectedPeerData);
     });
@@ -88,7 +86,7 @@ describe("Signal", () => {
     it("should gracefully fail to sign in", async () => {
       fetchMock.mockRejectOnce(new Error("Mock Failure"));
 
-      await expect(testInstance.signIn("peerName", "peerService", true)).rejects.toBeInstanceOf(Error);
+      await expect(testInstance.signIn("peerName", true)).rejects.toBeInstanceOf(Error);
     });
 
     it("should fail if no peer id is returned", async () => {
@@ -96,7 +94,7 @@ describe("Signal", () => {
         headers: {},
       });
 
-      await expect(testInstance.signIn("peerName", "peerService", true)).rejects.toBeInstanceOf(Error);
+      await expect(testInstance.signIn("peerName", true)).rejects.toBeInstanceOf(Error);
     });
   });
 
@@ -184,7 +182,7 @@ describe("Signal", () => {
       });
       testInstance.on("peer-message", onPeerMessage);
 
-      await testInstance.signIn("name", "service", true);
+      await testInstance.signIn("name", true);
       expect(global.setInterval).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(1000);
 
@@ -218,7 +216,7 @@ describe("Signal", () => {
       });
       testInstance.on("peer-update", onPeerUpdate);
 
-      await testInstance.signIn("name", "service", true);
+      await testInstance.signIn("name", true);
       expect(global.setInterval).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(1000);
 
@@ -246,7 +244,7 @@ describe("Signal", () => {
       });
       testInstance.on("error", onError);
 
-      await testInstance.signIn("name", "service", true);
+      await testInstance.signIn("name", true);
       expect(global.setInterval).toHaveBeenCalledTimes(1);
       jest.advanceTimersByTime(1000);
 

--- a/src/browserd.ts
+++ b/src/browserd.ts
@@ -10,7 +10,6 @@ logger.info(`working directory: ${process.cwd()}`);
  * Configure our environment variables from dotenv
  * Supported:
  *  + SERVICE_URL (string) - the web service address (to render)
- *  + PEER_SERVICE (string) - the window and stream source name
  *  + TURN_URL (string) - a turn address
  *  + TURN_USERNAME (string) - a turn username
  *  + TURN_PASSWORD (string) - a turn password credential
@@ -28,7 +27,6 @@ if (envParserStatus.error) {
 }
 [
     "SERVICE_URL",
-    "PEER_SERVICE",
     "TURN_URL",
     "TURN_USERNAME",
     "TURN_PASSWORD",
@@ -49,8 +47,8 @@ let streamerWindow: BrowserWindow;
 
 // when eletron is ready to go, we begin
 app.on("ready", async () => {
-    // we'll name our window after the peer service (this is critical, as it's how we'll get the video stream)
-    const captureWindowTitle = process.env.PEER_SERVICE as string;
+    // we'll name our window after the service url (this is critical, as it's how we'll get the video stream)
+    const captureWindowTitle = process.env.SERVICE_URL as string;
 
     // we need to share some state with the capturer (in a different process) - so we set that up here
     (global as NodeJS.Global & {sharedObject: ISharedObject})[sharedObjectKeyName] = {
@@ -64,7 +62,6 @@ app.on("ready", async () => {
                 username: process.env.TURN_USERNAME,
             },
         ],
-        peerService: captureWindowTitle,
         pollInterval: Number.parseInt(process.env.POLL_INTERVAL as string, 10).valueOf(),
         pollUrl: process.env.POLL_URL as string,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,7 +324,6 @@ export interface ISharedObject {
     allowPreload: boolean;
     captureWindowTitle: string;
     iceServers: RTCIceServer[];
-    peerService: string;
     pollInterval: number;
     pollUrl: string;
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -49,7 +49,6 @@ export function startWebrtcProvider(so: ISharedObject, logger: Logger) {
     const {
         captureWindowTitle,
         iceServers,
-        peerService,
         pollInterval,
         pollUrl } = so;
     const captureWindow = remote.BrowserWindow.getAllWindows().find((w) => w.getTitle() === captureWindowTitle);
@@ -85,7 +84,7 @@ export function startWebrtcProvider(so: ISharedObject, logger: Logger) {
                 pollIntervalMs: pollInterval,
                 url: pollUrl,
             });
-            await sig.signIn(captureWindowTitle + uuid(), peerService, true);
+            await sig.signIn(captureWindowTitle + uuid(), true);
             sig.on("error", (err) => {
                 logger.error(`sig fail: ${err}`);
             });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -84,7 +84,7 @@ export function startWebrtcProvider(so: ISharedObject, logger: Logger) {
                 pollIntervalMs: pollInterval,
                 url: pollUrl,
             });
-            await sig.signIn(captureWindowTitle + uuid(), true);
+            await sig.signIn(captureWindowTitle + uuid());
             sig.on("error", (err) => {
                 logger.error(`sig fail: ${err}`);
             });

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -80,11 +80,10 @@ export class Signal extends (EventEmitter as new() => SignalEmitter) {
     /**
      * Sign in to the signaler
      * @param peerName the peer name to register as
-     * @param isProvider indicates if this peer is a service provider or consumer
      */
-    public signIn(peerName: string, isProvider = true) {
+    public signIn(peerName: string) {
         return fetch(url.resolve(this.url,
-            `/sign_in?peer_name=${peerName}&is_stream_provider=${isProvider}`))
+            `/sign_in?peer_name=${peerName}`))
             .then((res) => {
                 if (!res.ok) {
                     throw new Error(`Invalid Response: ${res.status}`);

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -80,12 +80,11 @@ export class Signal extends (EventEmitter as new() => SignalEmitter) {
     /**
      * Sign in to the signaler
      * @param peerName the peer name to register as
-     * @param peerService the peer service to register for
      * @param isProvider indicates if this peer is a service provider or consumer
      */
-    public signIn(peerName: string, peerService: string, isProvider = true) {
+    public signIn(peerName: string, isProvider = true) {
         return fetch(url.resolve(this.url,
-            `/sign_in?peer_name=${peerName}&peer_service=${peerService}&is_stream_provider=${isProvider}`))
+            `/sign_in?peer_name=${peerName}&is_stream_provider=${isProvider}`))
             .then((res) => {
                 if (!res.ok) {
                     throw new Error(`Invalid Response: ${res.status}`);


### PR DESCRIPTION
Updating our readme file about the signaling server and removing `peerService` parameter to fix #13 