### PR TITLE
Supporting Twilio's STUN/TURN service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ key and value per line. For example `KEY=value`. Below are the possible options:
 + `TWILIO_ACCOUNT_SID` (string) - a Twilio AccountSid required to get a Network Traversal Service Token
 + `TWILIO_AUTH_TOKEN` (string) - a Twilio AuthToken required to get a Network Traversal Service Token
 
+## Turn server
+
+Our service supports both [coturn](https://github.com/coturn/coturn) and [Twilio's STUN/TURN service](https://www.twilio.com/docs/stun-turn).
+In the dotenv file, if `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` values are set, our service will attempt to get a turn server from Twilio. Otherwise, you can leave them empty to use a stun server or coturn turn server.
+
 ## Running
 
 How to get browserd up and running. ⚙

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ key and value per line. For example `KEY=value`. Below are the possible options:
 + `HEIGHT` (number) - the window height
 + `WIDTH` (number) - the window width
 + `EXP_HIDE_STREAMER` (boolean) - experiment flag for hiding the streamer window
++ `TWILIO_ACCOUNT_SID` (string) - a Twilio AccountSid required to get a Network Traversal Service Token
++ `TWILIO_AUTH_TOKEN` (string) - a Twilio AuthToken required to get a Network Traversal Service Token
 
 ## Running
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -31,18 +31,21 @@
     },
     "envTurnUrl": {
       "type": "string",
+      "defaultValue": "stun:stun.l.google.com:19302",
       "metadata": {
         "description": "a turn address"
       }
     },
     "envTurnUsername": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
         "description": "a turn username"
       }
     },
     "envTurnPassword": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
         "description": "a turn password"
       }
@@ -75,6 +78,20 @@
       "type": "string",
       "metadata": {
         "description": "experiment flag for hiding the streamer window"
+      }
+    },
+    "envTwilioAccountSid": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Twilio AccountSid required for Traversal Service Token retrieval"
+      }
+    },
+    "envTwilioAuthToken": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Twilio AuthToken required for Traversal Service Token retrieval"
       }
     }
   },
@@ -132,6 +149,14 @@
                 {
                   "name": "EXP_HIDE_STREAMER",
                   "value": "[parameters('envExpHideStreamer')]"
+                },
+                {
+                  "name": "TWILIO_ACCOUNT_SID",
+                  "value": "[parameters('envTwilioAccountSid')]"
+                },
+                {
+                  "name": "TWILIO_AUTH_TOKEN",
+                  "value": "[parameters('envTwilioAuthToken')]"
                 }
               ]
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,6 +450,23 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/debug": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.4.tgz",
@@ -463,6 +480,25 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+      "integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -505,11 +541,15 @@
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
       "dev": true
     },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+    },
     "@types/node": {
       "version": "10.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
-      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==",
-      "dev": true
+      "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
     },
     "@types/pino": {
       "version": "5.8.8",
@@ -521,11 +561,25 @@
         "@types/sonic-boom": "*"
       }
     },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+    },
     "@types/sdp-transform": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/sdp-transform/-/sdp-transform-2.4.0.tgz",
       "integrity": "sha512-RWVFLpqNsUbz085OanSNKAtk64G/e9Ol+t5a3QpCxkloidHYFk41vKtWIPmLcZS0Sm87L93S+MC8SL5S1LBPRA==",
       "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
     },
     "@types/simple-peer": {
       "version": "6.1.5",
@@ -606,7 +660,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -794,11 +847,15 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -806,8 +863,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -836,8 +892,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -848,14 +903,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-jest": {
       "version": "24.8.0",
@@ -984,7 +1037,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1156,6 +1208,11 @@
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -1312,8 +1369,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -1461,7 +1517,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1650,7 +1705,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1788,8 +1842,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "deprecate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
+      "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -1864,10 +1922,17 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ejs": {
@@ -2288,8 +2353,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2409,20 +2473,17 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2516,14 +2577,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -3169,7 +3228,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3249,14 +3307,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -3346,7 +3402,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -3638,8 +3693,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -3692,8 +3746,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -4249,8 +4302,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "11.12.0",
@@ -4307,20 +4359,17 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.1.0",
@@ -4340,16 +4389,51 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keyv": {
@@ -4445,8 +4529,42 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -4652,14 +4770,12 @@
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "dev": true
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.40.0"
       }
@@ -4728,6 +4844,11 @@
           "dev": true
         }
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.1.1",
@@ -4886,8 +5007,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -5191,8 +5311,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -5278,6 +5397,11 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
+    },
+    "pop-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",
+      "integrity": "sha1-zqz9q0q/NT16DyqqLB/Hs/lBO6M="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -5367,8 +5491,7 @@
     "psl": {
       "version": "1.1.32",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
-      "dev": true
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
     },
     "pump": {
       "version": "3.0.0",
@@ -5383,14 +5506,22 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "q": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
+      "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
+      "requires": {
+        "asap": "^2.0.0",
+        "pop-iterate": "^1.0.1",
+        "weak-map": "^1.0.5"
+      }
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "quick-format-unescaped": {
       "version": "3.0.2",
@@ -5581,7 +5712,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -5691,6 +5821,11 @@
         "glob": "^7.1.3"
       }
     },
+    "rootpath": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rootpath/-/rootpath-0.1.2.tgz",
+      "integrity": "sha1-Wzeah9ypBum5HWkKWZQ5vvJn6ms="
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -5714,8 +5849,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -5749,6 +5883,11 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "scmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.0.0.tgz",
+      "integrity": "sha1-JHEQ7yLM+JexOj8KvdtSeCOTzWo="
+    },
     "sdp-transform": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.8.0.tgz",
@@ -5757,8 +5896,7 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -6123,7 +6261,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -6531,7 +6668,6 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -6540,8 +6676,7 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
       }
     },
@@ -6649,7 +6784,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -6657,8 +6791,31 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "twilio": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.32.0.tgz",
+      "integrity": "sha512-6SII8R7y9GDzoZK0NRMwohSqHvEhOdT2lBBp6oQ0NlzetbP0xewCIf0XpxmucOqxJjoPit4tfO/vO+r2K18sVg==",
+      "requires": {
+        "@types/express": "^4.16.1",
+        "deprecate": "1.0.0",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.11",
+        "moment": "^2.24.0",
+        "q": "2.0.x",
+        "request": "^2.88.0",
+        "rootpath": "0.1.2",
+        "scmp": "2.0.0",
+        "xmlbuilder": "9.0.1"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.1.tgz",
+          "integrity": "sha1-kc1wiXdVNj66V8Et3uq0o0GmH2U="
+        }
+      }
     },
     "type-check": {
       "version": "0.3.2",
@@ -6818,7 +6975,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -6884,7 +7040,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -6908,6 +7063,11 @@
       "requires": {
         "makeerror": "1.0.x"
       }
+    },
+    "weak-map": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sdp-transform": "^2.8.0",
     "simple-peer": "^9.3.0",
     "strict-event-emitter-types": "^2.0.0",
+    "twilio": "^3.32.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,13 +1,15 @@
 import {
   DesktopCapturer,
   desktopCapturer as hiddenDesktopCapturer,
-  DesktopCapturerSource } from "electron";
+  DesktopCapturerSource,
+} from "electron";
 import { parse as hiddenParseSdp, write as hiddenWriteSdp } from "sdp-transform";
 import {
   forceH264Sdp,
   getDesktopSources,
   parsePeers,
-  selectCaptureSource } from "..";
+  selectCaptureSource,
+} from "..";
 
 const desktopCapturer = hiddenDesktopCapturer as jest.Mocked<DesktopCapturer>;
 const parseSdp = hiddenParseSdp as jest.Mock;

--- a/src/__tests__/signal.spec.ts
+++ b/src/__tests__/signal.spec.ts
@@ -49,7 +49,7 @@ describe("Signal", () => {
       const expectedPeerName = "peerName";
       const expectedPeerId = "123";
       const expectedUrl = `${defaultCtorArgs.url}/sign_in?` +
-      `peer_name=${expectedPeerName}`;
+        `peer_name=${expectedPeerName}`;
       const expectedEmptyData = "";
 
       fetchMock.mockResponseOnce(expectedEmptyData, {
@@ -169,8 +169,8 @@ describe("Signal", () => {
       const expectedRemotePeerId = "321";
 
       fetchMock
-        .mockResponseOnce("", { status: 200 , headers: { pragma: expectedPeerId }})
-        .mockResponseOnce("hello", { status: 200 , headers: { pragma: expectedRemotePeerId }});
+        .mockResponseOnce("", { status: 200, headers: { pragma: expectedPeerId } })
+        .mockResponseOnce("hello", { status: 200, headers: { pragma: expectedRemotePeerId } });
 
       const onPeerMessage = jest.fn();
       const peerMessageCalled = new Promise((resolve) => {
@@ -197,8 +197,8 @@ describe("Signal", () => {
       const expectedParseRaiseEventData = "raised from parsed";
 
       fetchMock
-        .mockResponseOnce("", { status: 200 , headers: { pragma: expectedPeerId }})
-        .mockResponseOnce(expectedPeerData, { status: 200 , headers: { pragma: expectedPeerId }});
+        .mockResponseOnce("", { status: 200, headers: { pragma: expectedPeerId } })
+        .mockResponseOnce(expectedPeerData, { status: 200, headers: { pragma: expectedPeerId } });
 
       // we'll want to assert against the value (ensuring it's raised via our event)
       // so we must actually provide some value
@@ -231,8 +231,8 @@ describe("Signal", () => {
       const expectedRemotePeerId = "321";
 
       fetchMock
-        .mockResponseOnce("", { status: 200 , headers: { pragma: expectedPeerId }})
-        .mockResponseOnce("", { status: 404 , headers: { pragma: expectedRemotePeerId }});
+        .mockResponseOnce("", { status: 200, headers: { pragma: expectedPeerId } })
+        .mockResponseOnce("", { status: 404, headers: { pragma: expectedRemotePeerId } });
 
       const onError = jest.fn();
       const errorCalled = new Promise((resolve) => {

--- a/src/__tests__/turn.spec.ts
+++ b/src/__tests__/turn.spec.ts
@@ -1,0 +1,58 @@
+import { ITwilioIceServer, requestTwilioTurnServer } from "../turn";
+
+const mockTwilioClient = {
+  tokens: { create: jest.fn() },
+};
+
+jest.mock("twilio", () => jest.fn(() => {
+  return mockTwilioClient;
+}));
+
+describe("Turn", () => {
+  describe("requestTwilioTurnServer", () => {
+    const validAccountSid = "fakeAccountSid";
+    const validAuthToken = "fakeAuthToken";
+    const username = "fakeUsername";
+    const credential = "fakeCredential";
+    const twilioIceServers = [
+      { url: "stun:fakeStun" },
+      { url: "turn:fakeTurn1", username, credential },
+      { url: "turn:fakeTurn2", username, credential },
+    ] as ITwilioIceServer[];
+
+    const generateFakeIceServers = (accountSid: string, authToken: string) => {
+      if (accountSid !== validAccountSid || authToken !== validAuthToken) {
+        throw new Error("Invalid accountSid or authToken");
+      }
+
+      return { iceServers: twilioIceServers };
+    }
+
+    it("fail to authenticate", async () => {
+      const accountSid = "invalidAccountSid";
+      const authToken = "invalidAuthToken";
+      mockTwilioClient.tokens.create.mockImplementation(() => {
+        generateFakeIceServers(accountSid, authToken);
+      });
+
+      await expect(requestTwilioTurnServer(accountSid, authToken)).rejects.toThrowError();
+    });
+
+    it("should return only turn servers", async () => {
+      const accountSid = "fakeAccountSid";
+      const authToken = "fakeAuthToken";
+      mockTwilioClient.tokens.create.mockImplementation(() => {
+        return generateFakeIceServers(accountSid, authToken);
+      });
+
+      const iceServers = await requestTwilioTurnServer(accountSid, authToken);
+
+      expect(iceServers.length).toEqual(2);
+      iceServers.forEach((iceServer: RTCIceServer) => {
+        expect(iceServer.urls).toContain("turn:");
+        expect(iceServer.username).toEqual(username);
+        expect(iceServer.credential).toEqual(credential);
+      });
+    });
+  });
+});

--- a/src/__tests__/turn.spec.ts
+++ b/src/__tests__/turn.spec.ts
@@ -1,7 +1,9 @@
 import { ITwilioIceServer, requestTwilioTurnServer } from "../turn";
 
 const mockTwilioClient = {
-  tokens: { create: jest.fn() },
+  tokens: {
+    create: jest.fn(),
+  },
 };
 
 jest.mock("twilio", () => jest.fn(() => {
@@ -47,11 +49,18 @@ describe("Turn", () => {
 
       const iceServers = await requestTwilioTurnServer(accountSid, authToken);
 
-      expect(iceServers.length).toEqual(2);
+      expect(iceServers.length).toEqual(3);
       iceServers.forEach((iceServer: RTCIceServer) => {
-        expect(iceServer.urls).toContain("turn:");
-        expect(iceServer.username).toEqual(username);
-        expect(iceServer.credential).toEqual(credential);
+        const isTurn = (iceServer.urls as string).startsWith("turn:");
+        if (isTurn) {
+          expect(iceServer.username).toEqual(username);
+          expect(iceServer.credential).toEqual(credential);
+          expect(iceServer.credentialType).toEqual("password");
+        } else {
+          expect(iceServer.username).toBeFalsy();
+          expect(iceServer.credential).toBeFalsy();
+          expect(iceServer.credentialType).toBeFalsy();
+        }
       });
     });
   });

--- a/src/browserd.ts
+++ b/src/browserd.ts
@@ -1,6 +1,7 @@
 import { config as configEnv } from "dotenv";
 import { app, BrowserWindow } from "electron";
-import {default as pino} from "pino";
+import { default as pino } from "pino";
+import { default as twilio } from "twilio";
 import { createWindow, ISharedObject, sharedObjectKeyName } from ".";
 
 const logger = pino();
@@ -18,6 +19,8 @@ logger.info(`working directory: ${process.cwd()}`);
  *  + HEIGHT (number) - the window height
  *  + WIDTH (number) - the window width
  *  + EXP_HIDE_STREAMER (boolean) - experiment flag for hiding the streamer window
+ *  + TWILIO_ACCOUNT_SID (string) - a Twilio AccountSid required to get a Network Traversal Service Token
+ *  + TWILIO_AUTH_TOKEN (string) - a Twilio AuthToken required to get a Network Traversal Service Token
  */
 const envParserStatus = configEnv();
 if (envParserStatus.error) {
@@ -35,6 +38,8 @@ if (envParserStatus.error) {
     "WIDTH",
     "HEIGHT",
     "EXP_HIDE_STREAMER",
+    "TWILIO_ACCOUNT_SID",
+    "TWILIO_AUTH_TOKEN",
 ].filter((expectedEnvKey) => {
     return process.env[expectedEnvKey] === undefined;
 }).forEach((key) => {
@@ -47,21 +52,49 @@ let streamerWindow: BrowserWindow;
 
 // when eletron is ready to go, we begin
 app.on("ready", async () => {
+    // TURN servers array
+    let iceServers: RTCIceServer[] = [];
+
+    try {
+        // We prioritize Twilio over coturn for turn servers
+        if (process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN) {
+            const client = twilio(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+            const token = await client.tokens.create();
+            const twilioIceServers = JSON.parse(JSON.stringify(token.iceServers));
+            twilioIceServers.forEach((twilioIceServer: { url: string, username?: string, credential?: string }) => {
+                // Filter out turn servers
+                if (twilioIceServer.url.startsWith("turn:")) {
+                    iceServers.push({
+                        credential: twilioIceServer.credential,
+                        credentialType: "password",
+                        urls: twilioIceServer.url,
+                        username: twilioIceServer.username,
+                    });
+                }
+            });
+        } else {
+            iceServers = [
+                {
+                    credential: process.env.TURN_PASSWORD,
+                    credentialType: "password",
+                    urls: [process.env.TURN_URL as string],
+                    username: process.env.TURN_USERNAME,
+                },
+            ];
+        }
+    } catch (err) {
+        logger.error(err);
+        process.exit(-1);
+    }
+
     // we'll name our window after the service url (this is critical, as it's how we'll get the video stream)
     const captureWindowTitle = process.env.SERVICE_URL as string;
 
     // we need to share some state with the capturer (in a different process) - so we set that up here
-    (global as NodeJS.Global & {sharedObject: ISharedObject})[sharedObjectKeyName] = {
+    (global as NodeJS.Global & { sharedObject: ISharedObject })[sharedObjectKeyName] = {
         allowPreload: true,
         captureWindowTitle,
-        iceServers: [
-            {
-                credential: process.env.TURN_PASSWORD,
-                credentialType: "password",
-                urls: [ process.env.TURN_URL as string ],
-                username: process.env.TURN_USERNAME,
-            },
-        ],
+        iceServers: this.iceServers,
         pollInterval: Number.parseInt(process.env.POLL_INTERVAL as string, 10).valueOf(),
         pollUrl: process.env.POLL_URL as string,
     };

--- a/src/browserd.ts
+++ b/src/browserd.ts
@@ -55,23 +55,18 @@ app.on("ready", async () => {
     // TURN servers array
     let iceServers: RTCIceServer[] = [];
 
-    try {
-        // We prioritize Twilio over coturn for turn servers
-        if (process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN) {
-            iceServers = await requestTwilioTurnServer(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
-        } else {
-            iceServers = [
-                {
-                    credential: process.env.TURN_PASSWORD,
-                    credentialType: "password",
-                    urls: [process.env.TURN_URL as string],
-                    username: process.env.TURN_USERNAME,
-                },
-            ];
-        }
-    } catch (err) {
-        logger.error(err);
-        process.exit(-1);
+    // We prioritize Twilio over coturn for turn servers
+    if (process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN) {
+        iceServers = await requestTwilioTurnServer(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+    } else {
+        iceServers = [
+            {
+                credential: process.env.TURN_PASSWORD,
+                credentialType: "password",
+                urls: [process.env.TURN_URL as string],
+                username: process.env.TURN_USERNAME,
+            },
+        ];
     }
 
     // we'll name our window after the service url (this is critical, as it's how we'll get the video stream)

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -9,7 +9,8 @@ import {
     getDesktopSources,
     ISharedObject,
     selectCaptureSource,
-    sharedObjectKeyName } from ".";
+    sharedObjectKeyName,
+} from ".";
 import { Signal } from "./signal";
 
 const preloadLogger = pino();
@@ -106,7 +107,7 @@ export function startWebrtcProvider(so: ISharedObject, logger: Logger) {
             });
             webrtc.on("data", (data) => {
                 data = data.toString();
-                const imsg = JSON.parse(data) as {type: string, version: number, data: any};
+                const imsg = JSON.parse(data) as { type: string, version: number, data: any };
                 fireInputEvent(captureWindow.webContents, imsg);
             });
         })

--- a/src/turn.ts
+++ b/src/turn.ts
@@ -1,0 +1,47 @@
+import { default as twilio } from "twilio";
+
+/**
+ * Twilio ice server
+ */
+export interface ITwilioIceServer {
+    /**
+     * The STUN/TURN endpoint url
+     */
+    url: string;
+
+    /**
+     * The username required for authentication (TURN endpoint only)
+     */
+    username?: string;
+
+    /**
+     * The credential required for authentication (TURN endpoint only)
+     */
+    credential?: string;
+}
+
+/**
+ * Request TURN servers from Twilio
+ * @param accountSid Twilio AccountSid required for Traversal Service Token retrieval
+ * @param authToken Twilio AuthToken required for Traversal Service Token retrieval
+ * @returns {RTCIceServer[]} the array of TURN servers
+ */
+export const requestTwilioTurnServer = async (accountSid: string, authToken: string) => {
+    const client = twilio(accountSid, authToken);
+    const token = await client.tokens.create();
+    const twilioIceServers = JSON.parse(JSON.stringify(token.iceServers));
+    const iceServers: RTCIceServer[] = [];
+    twilioIceServers.forEach((twilioIceServer: ITwilioIceServer) => {
+        // Filter out turn servers
+        if (twilioIceServer.url.startsWith("turn:")) {
+            iceServers.push({
+                credential: twilioIceServer.credential,
+                credentialType: "password",
+                urls: twilioIceServer.url,
+                username: twilioIceServer.username,
+            });
+        }
+    });
+
+    return iceServers;
+};

--- a/src/turn.ts
+++ b/src/turn.ts
@@ -32,13 +32,16 @@ export const requestTwilioTurnServer = async (accountSid: string, authToken: str
     const twilioIceServers = JSON.parse(JSON.stringify(token.iceServers));
     const iceServers: RTCIceServer[] = [];
     twilioIceServers.forEach((twilioIceServer: ITwilioIceServer) => {
-        // Filter out turn servers
         if (twilioIceServer.url.startsWith("turn:")) {
             iceServers.push({
                 credential: twilioIceServer.credential,
                 credentialType: "password",
                 urls: twilioIceServer.url,
                 username: twilioIceServer.username,
+            });
+        } else {
+            iceServers.push({
+                urls: twilioIceServer.url,
             });
         }
     });


### PR DESCRIPTION
Support getting a turn server from [Twilio Network Traversal Service](https://www.twilio.com/docs/stun-turn) and use it in our [simple-peer](https://www.npmjs.com/package/simple-peer) library:

- Allow using either coturn or Twilio's turn server.
- Unit tests are included
- Azure deployment was fully tested and works