### PR TITLE
Improving electron security for our service

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ npm install
 npm start
 ```
 
+## Electron security
+
+Our service follows [electron security guideline](https://electronjs.org/docs/tutorial/security) and enables the following behaviors:
+
++ Enabling [contextIsolation](https://electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content), which allows scripts running in the renderer to make changes to its javascript environment without worrying about conflicting with the scripts in the electron API or the preload script.
++ Blocking [mouse middle-clicking](https://www.blackhat.com/docs/us-17/thursday/us-17-Carettoni-Electronegativity-A-Study-Of-Electron-Security-wp.pdf), which opens a new window and makes our remote input stop working.
++ Disabling popup dialog for file downloading (when clicking on a link) so that it doesn't interfere with the streamer window.
++ Displaying warning about using [insecure http protocol](https://electronjs.org/docs/tutorial/security#1-only-load-secure-content) or when the streamer window [navigates to a new origin](https://electronjs.org/docs/tutorial/security#12-disable-or-limit-navigation), which is different from the `SERVICE_URL`.
+
 ## Contributing
 
 Coming soon. ✨

--- a/src/__tests__/node/application.spec.ts
+++ b/src/__tests__/node/application.spec.ts
@@ -4,7 +4,8 @@ import {
   K_BROWSER_CONFIG,
   K_BROWSER_STORAGE,
   K_CAPTURE_WIN,
-  K_SIGNAL_CONFIG } from "../../base/constants";
+  K_SIGNAL_CONFIG,
+} from "../../base/constants";
 import { IWindow, IWindowProvider } from "../../base/window-provider";
 import { Application } from "../../node/application";
 
@@ -55,6 +56,9 @@ describe("Application", () => {
       height: expectedHeight,
       title: expectedWindowTitle,
       url: expectedUrl,
+      webPreferences: {
+        contextIsolation: true,
+      },
       width: expectedWidth,
     });
     // note: the values here are __not__ driven by config
@@ -68,7 +72,7 @@ describe("Application", () => {
     });
     expect(Window.hide).toHaveBeenCalledTimes(1);
 
-    const globalStorage: {[key: string]: any} = {};
+    const globalStorage: { [key: string]: any } = {};
     globalStorage[K_CAPTURE_WIN] = expectedWindowTitle;
     globalStorage[K_BROWSER_CONFIG] = {
       iceServers: expectedIceServers,

--- a/src/__tests__/node/application.spec.ts
+++ b/src/__tests__/node/application.spec.ts
@@ -29,12 +29,13 @@ describe("Application", () => {
     const expectedPollUrl = "http://poll.test.com";
     const expectedInterval = 1020;
     const expectedIceServers: RTCIceServer[] = [];
+    const logger = pino();
 
     const instance = new Application({
       captureWindowTitle: expectedWindowTitle,
       expHideStreamer: expectedHideStreamer,
       height: expectedHeight,
-      logger: pino(),
+      logger,
       signalConfig: {
         pollIntervalMs: expectedInterval,
         url: expectedPollUrl,
@@ -54,6 +55,7 @@ describe("Application", () => {
       alwaysOnTop: true,
       backgroundColor: "#000",
       height: expectedHeight,
+      logger,
       title: expectedWindowTitle,
       url: expectedUrl,
       webPreferences: {
@@ -65,6 +67,7 @@ describe("Application", () => {
     // note: the values here are __not__ driven by config
     expect(WinProvider.createWindow).toHaveBeenNthCalledWith(2, {
       height: 10,
+      logger,
       url: "chrome://webrtc-internals",
       webPreferences: {
         preload: path.join(__dirname, "../../browser/main.js"),

--- a/src/__tests__/node/application.spec.ts
+++ b/src/__tests__/node/application.spec.ts
@@ -58,6 +58,7 @@ describe("Application", () => {
       url: expectedUrl,
       webPreferences: {
         contextIsolation: true,
+        disableBlinkFeatures: "Auxclick",
       },
       width: expectedWidth,
     });

--- a/src/__tests__/node/win.spec.ts
+++ b/src/__tests__/node/win.spec.ts
@@ -4,15 +4,10 @@ import {
   Session as ElectronSession,
   WebContents as ElectronWebContents,
 } from "electron";
+import pino from "pino";
 import { Win } from "../../node/win";
 
-const logger = {
-  warn: jest.fn(),
-};
-
-jest.mock("pino", () => jest.fn(() => {
-  return logger;
-}));
+jest.mock("pino");
 
 const Session: jest.Mocked<ElectronSession> = {
   on: jest.fn(),
@@ -47,14 +42,17 @@ describe("Win", () => {
     const expectedUrl = "https://test.com";
     const expectedTitle = "windowTitle";
     const instance = new Win();
+    const logger = pino();
 
     const win = await instance.createWindow({
+      logger,
       title: expectedTitle,
       url: expectedUrl,
     });
 
     expect(ElectronBrowserWindow).toHaveBeenCalledTimes(1);
     expect(ElectronBrowserWindow).toHaveBeenCalledWith({
+      logger,
       show: false,
       title: expectedTitle,
       url: expectedUrl,

--- a/src/__tests__/node/win.spec.ts
+++ b/src/__tests__/node/win.spec.ts
@@ -1,15 +1,28 @@
-import { BrowserWindow as ElectronBrowserWindow, Event as ElectronEvent } from "electron";
+import {
+  BrowserWindow as ElectronBrowserWindow,
+  Event as ElectronEvent,
+  Session as ElectronSession,
+  WebContents as ElectronWebContents,
+} from "electron";
 import { Win } from "../../node/win";
 
-const session = {
-  on: jest.fn(),
-}
+const logger = {
+  warn: jest.fn(),
+};
 
-const webContents = {
+jest.mock("pino", () => jest.fn(() => {
+  return logger;
+}));
+
+const Session: jest.Mocked<ElectronSession> = {
+  on: jest.fn(),
+} as Partial<ElectronWebContents> as any;
+
+const WebContents: jest.Mocked<ElectronWebContents> = {
   loadURL: jest.fn(),
   on: jest.fn(),
-  session,
-} as any;
+  session: Session,
+} as Partial<ElectronWebContents> as any;
 
 const BrowserWindow: jest.Mocked<ElectronBrowserWindow> = {
   loadURL: jest.fn().mockImplementation(() => Promise.resolve()),
@@ -18,7 +31,7 @@ const BrowserWindow: jest.Mocked<ElectronBrowserWindow> = {
     cb();
   }),
   show: jest.fn(),
-  webContents,
+  webContents: WebContents,
 } as Partial<ElectronBrowserWindow> as any;
 
 jest.mock("electron", () => {
@@ -51,13 +64,70 @@ describe("Win", () => {
     const evt: ElectronEvent = {
       preventDefault: jest.fn(),
     } as Partial<ElectronEvent> as any;
+    const webContents = BrowserWindow.webContents as jest.Mocked<ElectronWebContents>;
+    const session = BrowserWindow.webContents.session as jest.Mocked<ElectronSession>;
 
+    // BrowserWindow events
     type PageTitleEventHandler = (evt: ElectronEvent) => void;
+
     // the 1st entry (0th index) in calls is the "page-title-updated" event
     // so this fires the event, and ensures that is is prevented
     const pageTitleEvent = BrowserWindow.on.mock.calls[0][1];
     const emitPageTitleUpdated = pageTitleEvent as unknown as PageTitleEventHandler;
     emitPageTitleUpdated(evt);
     expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+
+    // BrowserWindow.webContents events
+    type DidStartNavigationEventHandler = (evt: ElectronEvent, url: string) => void;
+    type NewWindowEventHandler = (evt: ElectronEvent) => void;
+    type WillNavigateEventHandler = (evt: ElectronEvent, url: string) => void;
+
+    // the 1st entry in calls is the "did-start-navigation" event
+    // so this fires the event, and ensures that the warning logs
+    // is displayed properly
+    const didStartNavigationEvent = webContents.on.mock.calls[0][1];
+    const emitDidStartNavigationEvent = didStartNavigationEvent as unknown as DidStartNavigationEventHandler;
+
+    // should not warn
+    emitDidStartNavigationEvent(evt, "https://test.com");
+    expect(logger.warn).toHaveBeenCalledTimes(0);
+
+    // should warn for insecure http protocol
+    emitDidStartNavigationEvent(evt, "http://test.com");
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+
+    // should warn for navigating to a different origin
+    emitDidStartNavigationEvent(evt, "https://test2.com");
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+
+    // the 2nd entry in calls is the "new-window" event
+    // so this fires the event, and ensures that is is prevented
+    const newWindowEvent = webContents.on.mock.calls[1][1];
+    const emitNewWindowEvent = newWindowEvent as unknown as NewWindowEventHandler;
+    emitNewWindowEvent(evt);
+    expect(evt.preventDefault).toHaveBeenCalledTimes(2);
+
+    // the 3rd entry in calls is the "will-navigate" event
+    // so this fires the event, and ensures that is is prevented
+    const willNavigateEvent = webContents.on.mock.calls[2][1];
+    const emitWillNavigateEvent = willNavigateEvent as unknown as WillNavigateEventHandler;
+
+    // should not block
+    emitWillNavigateEvent(evt, "http://test.com/test.txt");
+    expect(evt.preventDefault).toHaveBeenCalledTimes(2);
+
+    // should block executing javascript file
+    emitWillNavigateEvent(evt, "http://test.com/test.js");
+    expect(evt.preventDefault).toHaveBeenCalledTimes(3);
+
+    // BrowserWindow.webContents.session events
+    type WillDownloadEventHandler = (evt: ElectronEvent) => void;
+
+    // the 1st entry in calls is the "will-download" event
+    // so this fires the event, and ensures that is is prevented
+    const willDownloadEvent = session.on.mock.calls[0][1];
+    const emitWillDownloadEvent = willDownloadEvent as unknown as WillDownloadEventHandler;
+    emitWillDownloadEvent(evt);
+    expect(evt.preventDefault).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/__tests__/node/win.spec.ts
+++ b/src/__tests__/node/win.spec.ts
@@ -1,6 +1,11 @@
 import { BrowserWindow as ElectronBrowserWindow, Event as ElectronEvent } from "electron";
 import { Win } from "../../node/win";
 
+const webContents = {
+  loadURL: jest.fn(),
+  on: jest.fn(),
+} as any;
+
 const BrowserWindow: jest.Mocked<ElectronBrowserWindow> = {
   loadURL: jest.fn().mockImplementation(() => Promise.resolve()),
   on: jest.fn(),
@@ -8,9 +13,10 @@ const BrowserWindow: jest.Mocked<ElectronBrowserWindow> = {
     cb();
   }),
   show: jest.fn(),
+  webContents,
 } as Partial<ElectronBrowserWindow> as any;
 
-jest.mock("electron" , () => {
+jest.mock("electron", () => {
   return {
     BrowserWindow: jest.fn().mockImplementation(() => {
       return BrowserWindow;
@@ -45,7 +51,7 @@ describe("Win", () => {
     // the 1st entry (0th index) in calls is the "page-title-updated" event
     // so this fires the event, and ensures that is is prevented
     const pageTitleEvent = BrowserWindow.on.mock.calls[0][1];
-    const emitPageTitleUpdated =  pageTitleEvent as unknown as PageTitleEventHandler;
+    const emitPageTitleUpdated = pageTitleEvent as unknown as PageTitleEventHandler;
     emitPageTitleUpdated(evt);
     expect(evt.preventDefault).toHaveBeenCalledTimes(1);
   });

--- a/src/__tests__/node/win.spec.ts
+++ b/src/__tests__/node/win.spec.ts
@@ -1,9 +1,14 @@
 import { BrowserWindow as ElectronBrowserWindow, Event as ElectronEvent } from "electron";
 import { Win } from "../../node/win";
 
+const session = {
+  on: jest.fn(),
+}
+
 const webContents = {
   loadURL: jest.fn(),
   on: jest.fn(),
+  session,
 } as any;
 
 const BrowserWindow: jest.Mocked<ElectronBrowserWindow> = {

--- a/src/base/window-provider.ts
+++ b/src/base/window-provider.ts
@@ -1,9 +1,15 @@
 import { BrowserWindow, BrowserWindowConstructorOptions } from "electron";
+import { Logger } from "pino";
 
 /**
  * Window construction options
  */
 export interface IWindowConstructorOpts extends Partial<BrowserWindowConstructorOptions> {
+  /**
+   * A logger
+   */
+  logger: Logger;
+
   /**
    * The url of the page to load
    */

--- a/src/node/application.ts
+++ b/src/node/application.ts
@@ -95,6 +95,7 @@ export class Application implements IApplication {
       alwaysOnTop: true,
       backgroundColor: "#000",
       height,
+      logger,
       title: captureWindowTitle,
       url,
       webPreferences: {
@@ -120,6 +121,7 @@ export class Application implements IApplication {
 
     const streamerWindow = await winProvider.createWindow({
       height: 10,
+      logger,
       url: "chrome://webrtc-internals",
       webPreferences: {
         // this is what triggers our actual streamer logic (webrtc init and whatnot)

--- a/src/node/application.ts
+++ b/src/node/application.ts
@@ -97,6 +97,9 @@ export class Application implements IApplication {
       height,
       title: captureWindowTitle,
       url,
+      webPreferences: {
+        contextIsolation: true,
+      },
       width,
     });
 

--- a/src/node/application.ts
+++ b/src/node/application.ts
@@ -99,6 +99,7 @@ export class Application implements IApplication {
       url,
       webPreferences: {
         contextIsolation: true,
+        disableBlinkFeatures: "Auxclick",
       },
       width,
     });

--- a/src/node/win.ts
+++ b/src/node/win.ts
@@ -18,11 +18,6 @@ export class Win implements IWindowProvider {
     // internally, we need to use the raw version
     const rawWin = win.toBrowserWindow();
 
-    // block middle-clicking, which opens a new window
-    rawWin.webContents.on("new-window", (e) => {
-      e.preventDefault();
-    });
-
     rawWin.webContents.on("did-start-navigation", (_, url) => {
       const newURL = new URL(url);
 
@@ -34,6 +29,24 @@ export class Win implements IWindowProvider {
       // warn about navigating to different origins
       if (newURL.hostname && newURL.hostname !== originalURL.hostname) {
         logger.warn("Navigating to a different origin: " + newURL.hostname);
+      }
+    });
+
+    // block middle-clicking, which opens a new window
+    rawWin.webContents.on("new-window", (e) => {
+      e.preventDefault();
+    });
+
+    // disable downloading files
+    rawWin.webContents.session.on("will-download", (e) => {
+      e.preventDefault();
+    });
+
+    // disable executing javascript files
+    rawWin.webContents.on("will-navigate", (e, url) => {
+      const newURL = new URL(url);
+      if (newURL.pathname.endsWith(".js")) {
+        e.preventDefault();
       }
     });
 

--- a/src/node/win.ts
+++ b/src/node/win.ts
@@ -15,6 +15,11 @@ export class Win implements IWindowProvider {
     // internally, we need to use the raw version
     const rawWin = win.toBrowserWindow();
 
+    // block middle-clicking, which opens a new window
+    rawWin.webContents.on("new-window", (e) => {
+      e.preventDefault();
+    });
+
     rawWin.on("page-title-updated", (e) => {
       if (opts && opts.title) {
         e.preventDefault();

--- a/src/node/win.ts
+++ b/src/node/win.ts
@@ -1,5 +1,4 @@
 import { BrowserWindow as ElectronBrowserWindow } from "electron";
-import pino from "pino";
 import { IWindowConstructorOpts, IWindowProvider } from "../base/window-provider";
 import { BrowserWindow } from "./browser-window";
 
@@ -8,7 +7,7 @@ import { BrowserWindow } from "./browser-window";
  */
 export class Win implements IWindowProvider {
   public async createWindow(opts: IWindowConstructorOpts) {
-    const logger = pino();
+    const logger = opts.logger;
     const originalURL = new URL(opts.url);
     const win = new BrowserWindow(new ElectronBrowserWindow({
       ...opts,

--- a/src/node/win.ts
+++ b/src/node/win.ts
@@ -18,6 +18,12 @@ export class Win implements IWindowProvider {
     // internally, we need to use the raw version
     const rawWin = win.toBrowserWindow();
 
+    rawWin.on("page-title-updated", (e) => {
+      if (opts && opts.title) {
+        e.preventDefault();
+      }
+    });
+
     rawWin.webContents.on("did-start-navigation", (_, url) => {
       const newURL = new URL(url);
 
@@ -37,11 +43,6 @@ export class Win implements IWindowProvider {
       e.preventDefault();
     });
 
-    // disable downloading files
-    rawWin.webContents.session.on("will-download", (e) => {
-      e.preventDefault();
-    });
-
     // disable executing javascript files
     rawWin.webContents.on("will-navigate", (e, url) => {
       const newURL = new URL(url);
@@ -50,10 +51,9 @@ export class Win implements IWindowProvider {
       }
     });
 
-    rawWin.on("page-title-updated", (e) => {
-      if (opts && opts.title) {
-        e.preventDefault();
-      }
+    // disable downloading files
+    rawWin.webContents.session.on("will-download", (e) => {
+      e.preventDefault();
     });
 
     const windowShown = new Promise((resolve) => {


### PR DESCRIPTION
The following behaviors have been added to improve electron security:

+ Enabling [contextIsolation](https://electronjs.org/docs/tutorial/security#3-enable-context-isolation-for-remote-content), which allows scripts running in the renderer to make changes to its javascript environment without worrying about conflicting with the scripts in the electron API or the preload script.
+ Blocking [mouse middle-clicking](https://www.blackhat.com/docs/us-17/thursday/us-17-Carettoni-Electronegativity-A-Study-Of-Electron-Security-wp.pdf), which opens a new window and makes our remote input stop working.
+ Disabling popup dialog for file downloading (when clicking on a link) so that it doesn't interfere with the streamer window.
+ Displaying warning about using [insecure http protocol](https://electronjs.org/docs/tutorial/security#1-only-load-secure-content) or when the streamer window [navigates to a new origin](https://electronjs.org/docs/tutorial/security#12-disable-or-limit-navigation), which is different from the `SERVICE_URL`.

This will fix #17 after landing.