### PR TITLE
Disable shared memory usage in Chromium

### DIFF
--- a/components/stream-provider/Dockerfile
+++ b/components/stream-provider/Dockerfile
@@ -38,4 +38,4 @@ USER root
 # start x11 session (xvfb)
 # start browserd
 CMD service dbus start \
-  && su electron -c 'dbus-run-session -- xvfb-run -s "-ac -br -nocursor -screen 0 1920x1080x24 -nolisten tcp" browserd --no-sandbox --disable-gpu'
+  && su electron -c 'dbus-run-session -- xvfb-run -s "-ac -br -nocursor -screen 0 1920x1080x24 -nolisten tcp" browserd --no-sandbox --disable-gpu --disable-dev-shm-usage'


### PR DESCRIPTION
This PR fixes #35 #36 after landing.

Chromium by default uses [/dev/shm](https://www.cyberciti.biz/tips/what-is-devshm-and-its-practical-usage.html), which is **shared memory**, to allocate objects. That brings troubles for environments where shared memory is limited (Docker) or not available (Amazon Lambda). Many people have reported [this issue on Chromium repo](https://bugs.chromium.org/p/chromium/issues/detail?id=736452) since early 2018.

Docker by default has [64mb](https://docs.docker.com/engine/reference/run/) shared memory:

![docker](https://user-images.githubusercontent.com/9741323/66727266-099fda00-ee0c-11e9-9c62-ccb7c68ed954.JPG)

That is not enough for running Chrome/Electron so we need to increase the shared memory. Unfortunately, we can't use `--shm-size` parameter since it's [not supported in ACI](https://github.com/MicrosoftFeedback/aci-issues/issues/3).
The remaining option is asking Chromium not to use shared memory since the app's memory is many times bigger and safer to run. The `--disable-dev-shm-usage` flag available since [Chrome 65](https://developers.google.com/web/tools/puppeteer/troubleshooting#tips) completely disables the usage of shared memory.